### PR TITLE
Moved Pin selection to be KConfig values, so they can be modified on a board by board basis

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -33,4 +33,12 @@ menu "esp-cryptoauthlib"
         select MBEDTLS_ATCA_HW_ECDSA_VERIFY
         select MBEDTLS_ECP_DP_SECP256R1_ENABLED
 
+    config ACTA_I2C_SDA_PIN
+        int "I2C SDA pin used to communicate with the ATECC608A"
+        default 16
+
+    config ACTA_I2C_SCL_PIN
+        int "I2C SCL pin used to communicate with the ATECC608A"
+        default 17
+
 endmenu # cryptoauthlib

--- a/cryptoauthlib/lib/hal/hal_esp32_i2c.c
+++ b/cryptoauthlib/lib/hal/hal_esp32_i2c.c
@@ -20,8 +20,8 @@
 #include "esp_err.h"
 #include "esp_log.h"
 
-#define SDA_PIN                            16
-#define SCL_PIN                            17
+#define SDA_PIN                            CONFIG_ACTA_I2C_SDA_PIN
+#define SCL_PIN                            CONFIG_ACTA_I2C_SCL_PIN
 #define ACK_CHECK_EN                       0x1              /*!< I2C master will check ack from slave*/
 #define ACK_CHECK_DIS                      0x0              /*!< I2C master will not check ack from slave */
 #define ACK_VAL                            0x0              /*!< I2C ack value */


### PR DESCRIPTION
I am using this code on a board that is not a S2, so I can't use pin 16 and 17 as hard coded in the repository.  Instead, I have broken them out into KConfig values, so they can be modified on a project by project basis, without losing the default values.