### PR TITLE
Fix breaking change in ESP-IDF 4.3.0 or older and add user configurable device address

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,11 @@ idf_component_register(     SRC_DIRS        "${COMPONENT_SRCDIRS}"
                             EXCLUDE_SRCS    "${COMPONENT_EXCLUDE_SRCS}"
                             )
 
+if ( IDF_VERSION_MAJOR EQUAL 4 AND IDF_VERSION_MIN EQUAL OR LESS 3 AND IDF_VERSION_PATCH LESS 1 )
+    target_compile_definitions(${COMPONENT_LIB} PUBLIC "-DATCA_ENABLE_DEPRECATED" )
+endif()
+                        
+
 target_sources(${COMPONENT_LIB} PRIVATE ${COMPONENT_SRCS})
 target_compile_definitions(${COMPONENT_LIB} PRIVATE ${COMPONENT_CFLAGS})
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-pointer-sign)

--- a/Kconfig
+++ b/Kconfig
@@ -43,6 +43,8 @@ menu "esp-cryptoauthlib"
        
     config ATCA_I2C_ADDRESS
         hex "I2C device address of the ATECC608A"
-        default 0xC0
+        default 0xC0 if ATECC608A_TCUSTOM
+        default 0x6C if ATECC608A_TFLEX
+        default 0xC0 if ATECC608A_TCUSTOM
 
 endmenu # cryptoauthlib

--- a/Kconfig
+++ b/Kconfig
@@ -40,5 +40,9 @@ menu "esp-cryptoauthlib"
     config ATCA_I2C_SCL_PIN
         int "I2C SCL pin used to communicate with the ATECC608A"
         default 17
+       
+    config ATCA_I2C_ADDRESS
+        hex "I2C device address of the ATECC608A"
+        default 0xC0
 
 endmenu # cryptoauthlib

--- a/cryptoauthlib/lib/atca_basic.c
+++ b/cryptoauthlib/lib/atca_basic.c
@@ -222,14 +222,17 @@ uint8_t atcab_get_device_address(ATCADevice device)
         switch (device->mIface.mIfaceCFG->iface_type)
         {
         case ATCA_I2C_IFACE:
+#ifdef ATCA_ENABLE_DEPRECATED
+            return device->mIface.mIfaceCFG->atcai2c.slave_address;
+#else
             return device->mIface.mIfaceCFG->atcai2c.address;
+#endif
         default:
             break;
         }
     }
     return 0xFF;
 }
-
 
 /** \brief Check whether the device is cryptoauth device
  *  \return True if device is cryptoauth device or False.

--- a/cryptoauthlib/lib/atca_iface.c
+++ b/cryptoauthlib/lib/atca_iface.c
@@ -153,7 +153,11 @@ ATCA_STATUS atsend(ATCAIface ca_iface, uint8_t address, uint8_t *txdata, int txl
 #ifdef ATCA_HAL_I2C
         if (ATCA_I2C_IFACE == ca_iface->mIfaceCFG->iface_type && 0xFF == address)
         {
+#ifdef ATCA_ENABLE_DEPRECATED
+            address = ca_iface->mIfaceCFG->atcai2c.slave_address;
+#else
             address = ca_iface->mIfaceCFG->atcai2c.address;
+#endif
         }
 #endif
 

--- a/cryptoauthlib/lib/pkcs11/pkcs11_config.c
+++ b/cryptoauthlib/lib/pkcs11/pkcs11_config.c
@@ -306,7 +306,11 @@ static CK_RV pkcs11_config_parse_interface(pkcs11_slot_ctx_ptr slot_ctx, char* c
         slot_ctx->interface_config.iface_type = ATCA_I2C_IFACE;
         if (argc > 1)
         {
+#ifdef ATCA_ENABLE_DEPRECATED
+            slot_ctx->interface_config.atcai2c.slave_address = (uint8_t)strtol(argv[1], NULL, 16);
+#else
             slot_ctx->interface_config.atcai2c.address = (uint8_t)strtol(argv[1], NULL, 16);
+#endif
         }
         if (argc > 2)
         {

--- a/cryptoauthlib/lib/pkcs11/pkcs11_slot.c
+++ b/cryptoauthlib/lib/pkcs11/pkcs11_slot.c
@@ -191,10 +191,17 @@ CK_RV pkcs11_slot_init(CK_SLOT_ID slotID)
     #ifdef ATCA_HAL_I2C
         if (ATCA_SUCCESS != status)
         {
+#ifdef ATCA_ENABLE_DEPRECATED
+            if (0xC0 != ifacecfg->atcai2c.slave_address)
+            {
+                /* Try the default address */
+                ifacecfg->atcai2c.slave_address = 0xC0;
+#else
             if (0xC0 != ifacecfg->atcai2c.address)
             {
                 /* Try the default address */
                 ifacecfg->atcai2c.address = 0xC0;
+#endif
                 atcab_release();
                 atca_delay_ms(1);
                 retries = 2;

--- a/port/atca_cfgs_port.c
+++ b/port/atca_cfgs_port.c
@@ -40,7 +40,11 @@
 ATCAIfaceCfg cfg_ateccx08a_i2c_default = {
     .iface_type             = ATCA_I2C_IFACE,
     .devtype                = ATECC608A,
+#ifdef ATCA_ENABLE_DEPRECATED
+    .atcai2c.slave_address  = CONFIG_ATCA_I2C_ADDRESS,
+#else
     .atcai2c.address        = CONFIG_ATCA_I2C_ADDRESS,
+#endif
     .atcai2c.bus            = 0,
     .atcai2c.baud           = 100000,
     .wake_delay             = 1500,

--- a/port/atca_cfgs_port.c
+++ b/port/atca_cfgs_port.c
@@ -40,7 +40,7 @@
 ATCAIfaceCfg cfg_ateccx08a_i2c_default = {
     .iface_type             = ATCA_I2C_IFACE,
     .devtype                = ATECC608A,
-    .atcai2c.address        = 0xC0,
+    .atcai2c.address        = CONFIG_ATCA_I2C_ADDRESS,
     .atcai2c.bus            = 0,
     .atcai2c.baud           = 100000,
     .wake_delay             = 1500,


### PR DESCRIPTION
This PR has two separate commits to expedite review.

1) For users who are using ESP-IDF 4.3.0 or older, this adds the `ATCA_ENABLE_DEPRECATED` definition to the project for backwards compatibility. Also fixes missing conditions in the Cryptoauthlib and configuration file.

2) Allows the user to set the peripheral address in the KConfig menu. This is valuable when an externally attached secure element is assigned a non-default device address.