### PR TITLE
Fixing PIP dependency for the esp_cryptoauth_utility

### DIFF
--- a/esp_cryptoauth_utility/requirements.txt
+++ b/esp_cryptoauth_utility/requirements.txt
@@ -1,4 +1,4 @@
-cryptography>=2.7
+cryptography==3.4.8
 pyasn1_modules==0.1.5
 pyasn1==0.3.7
 python-jose==3.1.0


### PR DESCRIPTION
On Windows, I am getting this error: `TypeError: argument 'data': 'bytearray' object cannot be converted to 'PyBytes'`.

```
Connecting....
Changing baud rate to 921600
Changed.
RAM boot...
Downloading 38168 bytes at 3ffb0000... done!
Downloading 488 bytes at 3ffba9f0... done!
Downloading 117300 bytes at 40080000... done!
Downloading 20 bytes at 4009ca34... done!
Downloading 16 bytes at 50000000... done!
All segments done, executing at 40081c90
Wait for init
- CLI Initialised
>>

init 21 22



←[0;32mI (2956) secure_element: I2C pins selected are SDA = 21, SCL = 22←[0m

←[0;32mI (4336) secure_element: Status: Success

>>

ATECC608 chip is of type Trust&Go
print-chip-info



←[0;32mI (4466) ATECC CHIP REVISION: 00 00 60 03 ←[0m

←[0;32mI (4466) secure_element: Since the last byte of chip revision is 0x03. This is an ATECC608B chip←[0m

←[0;32mI (4576) ATECC CHIP SERIAL NUMBER: 01 23 ae 96 78 3d e0 b8 01 ←[0m

←[0;32mI (4576) secure_element: Status: Success

>>

Serial Number:
0123AE96783DE0B801
Generating Manifest
get-tngtls-root-cert



←[0;32mI (4616) secure_element: Status: Success

>>

Traceback (most recent call last):
  File "secure_cert_mfg.py", line 203, in <module>
    main()
  File "secure_cert_mfg.py", line 105, in main
    hs.manifest.generate_manifest_file(esp, args, init_mfg)
  File "S:\m\freertos\samples\demos\projects\ESPRESSIF\esp32\components\esp-cryptoauthlib\esp_cryptoauth_utility\helper_scripts\manifest.py", line 141, in generate_manifest_file
    root_cert = x509.load_der_x509_certificate(root_cert_der, default_backend())
  File "C:\Espressif\python_env\idf4.4_py3.8_env\lib\site-packages\cryptography\x509\base.py", line 443, in load_der_x509_certificate
    return rust_x509.load_der_x509_certificate(data)
TypeError: argument 'data': 'bytearray' object cannot be converted to 'PyBytes'
```

The change forces cryptography to version `3.4.8` which works as expected: log ends with `Generated the manifest file 0123ae96783de0b801_manifest.json in output_files`


I have verified that the next cryptography version (35.0.0) will not work either.

This issue is similar to https://github.com/randywu763/sam-iot-provision/pull/1/files
