### PR TITLE
Configurable SDA and SCL pins for I2C0 and I2C1

### DIFF
--- a/cryptoauthlib/third_party/hal/esp32/hal_esp32_i2c.c
+++ b/cryptoauthlib/third_party/hal/esp32/hal_esp32_i2c.c
@@ -20,11 +20,9 @@
 #include "esp_log.h"
 #include "cryptoauthlib.h"
 
-#define I2C0_SDA_PIN                       CONFIG_ATCA_I2C_SDA_PIN
-#define I2C0_SCL_PIN                       CONFIG_ATCA_I2C_SCL_PIN
+#define I2C_SDA_PIN                       CONFIG_ATCA_I2C_SDA_PIN
+#define I2C_SCL_PIN                       CONFIG_ATCA_I2C_SCL_PIN
 
-#define I2C1_SDA_PIN                       21
-#define I2C1_SCL_PIN                       22
 #define ACK_CHECK_EN                       0x1              /*!< I2C master will check ack from slave*/
 #define ACK_CHECK_DIS                      0x0              /*!< I2C master will not check ack from slave */
 #define ACK_VAL                            0x0              /*!< I2C ack value */
@@ -107,19 +105,17 @@ ATCA_STATUS hal_i2c_init(ATCAIface iface, ATCAIfaceCfg *cfg)
 
             switch (bus)
             {
-            case 0:
-                i2c_hal_data[bus].id = I2C_NUM_0;
-                i2c_hal_data[bus].conf.sda_io_num = I2C0_SDA_PIN;
-                i2c_hal_data[bus].conf.scl_io_num = I2C0_SCL_PIN;
-                break;
-            case 1:
-                i2c_hal_data[bus].id = I2C_NUM_1;
-                i2c_hal_data[bus].conf.sda_io_num = I2C1_SDA_PIN;
-                i2c_hal_data[bus].conf.scl_io_num = I2C1_SCL_PIN;
-                break;
-            default:
-                break;
+                case 0:
+                    i2c_hal_data[bus].id = I2C_NUM_0;
+                    break;
+                case 1:
+                    i2c_hal_data[bus].id = I2C_NUM_1;
+                default:
+                    break;
             }
+
+            i2c_hal_data[bus].conf.sda_io_num = I2C_SDA_PIN;
+            i2c_hal_data[bus].conf.scl_io_num = I2C_SCL_PIN;
 
 //            ESP_LOGI(TAG, "Configuring I2C");
             rc = i2c_param_config(i2c_hal_data[bus].id, &i2c_hal_data[bus].conf);


### PR DESCRIPTION
- Make it possible to set SDA and SCL pins for I2C1
- Use one config I2C pins for I2C0 and I2C1